### PR TITLE
Fix face recognition: landmark coordinates are face-bbox-relative, not image-relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Configure via environment variables or edit `src/config.py`:
 | `ML_USE_COREML` | `true` | Enable CoreML acceleration |
 | `ML_USE_ANE` | `true` | Enable Apple Neural Engine |
 | `ML_MAX_CONCURRENT_REQUESTS` | `4` | Max queued requests before backpressure |
+| `MODEL_UNLOAD_STRATEGY` | `pressure` | `pressure`: unload when RAM is low + idle. `timeout`: unload after idle timeout. `never`: keep loaded. |
+| `MODEL_IDLE_TIMEOUT` | `120` | Seconds before unloading idle models (only used with `timeout` strategy) |
+| `MODEL_MEMORY_FLOOR_MB` | `500` | Available RAM threshold that triggers model unloading (only used with `pressure` strategy) |
 | `ML_LOG_LEVEL` | `INFO` | Logging verbosity (DEBUG/INFO/WARNING/ERROR) |
 | `ML_LOG_REQUESTS` | `true` | Log individual requests (disable for high volume) |
 | `ML_DEBUG_MODE` | `false` | Expose error details (keep false when network-exposed) |

--- a/src/main.py
+++ b/src/main.py
@@ -42,12 +42,19 @@ MODEL_MEMORY_FLOOR_MB = int(os.getenv("MODEL_MEMORY_FLOOR_MB", "500"))
 # Minimum idle time before a model is eligible for pressure-based unloading
 _PRESSURE_IDLE_MIN_SEC = 30
 _model_last_used: dict[str, float] = {}
+_model_busy: set[str] = set()  # models currently loading or running inference
 _idle_monitor_started = False
 
 
 def _track_model_use(model_type: str) -> None:
-    """Record that a model was just used."""
+    """Record that a model was just used (call AFTER load/inference, not before)."""
     _model_last_used[model_type] = _time.monotonic()
+    _model_busy.discard(model_type)
+
+
+def _mark_model_busy(model_type: str) -> None:
+    """Mark a model as actively loading or running inference (unload-protected)."""
+    _model_busy.add(model_type)
 
 
 def _available_memory_mb() -> int:
@@ -75,6 +82,9 @@ def _should_unload(model_type: str, now: float, avail_mb: int) -> bool:
     avail_mb is passed in so the caller can check memory once per cycle,
     not once per model.
     """
+    if model_type in _model_busy:
+        return False  # model is loading or mid-inference, never unload
+
     last_used = _model_last_used.get(model_type, now)
     idle_sec = now - last_used
 
@@ -239,12 +249,20 @@ async def log_requests(request: Request, call_next):
 
 
 def get_clip(model_name: str = "ViT-B-32__openai"):
-    """Get CLIP model, loading on first use or switching if model changed."""
+    """Get CLIP model, loading on first use or switching if model changed.
+
+    Marks CLIP as busy (unload-protected) during load. Callers must call
+    _track_model_use("clip") after inference completes to release the guard.
+    """
     if STUB_MODE:
         return None
     from .models.clip import get_clip_model
-    _track_model_use("clip")
-    return get_clip_model(model_name)
+    _mark_model_busy("clip")
+    try:
+        return get_clip_model(model_name)
+    except Exception:
+        _model_busy.discard("clip")  # don't leave a permanent busy flag on load failure
+        raise
 
 
 async def run_face_recognition_async(
@@ -269,28 +287,31 @@ def _run_face_recognition_sync(
     """Synchronous face recognition implementation."""
     from .models.face_detect import detect_faces
     from .models.face_embed import get_face_embedding, get_face_embedding_from_bbox
-    _track_model_use("face")
-    
-    faces, _, _ = detect_faces(image_bytes)
-    
-    results = []
-    for face in faces:
-        if face["score"] < min_score:
-            continue
-        
-        if "landmarks" in face:
-            embedding = get_face_embedding(image_bytes, face["landmarks"], model_name)
-        else:
-            embedding = get_face_embedding_from_bbox(image_bytes, face["boundingBox"], model_name)
-        
-        if embedding is not None:
-            results.append({
-                "boundingBox": face["boundingBox"],
-                "embedding": str(embedding.tolist()),
-                "score": face["score"]
-            })
-    
-    return results
+    _mark_model_busy("face")
+
+    try:
+        faces, _, _ = detect_faces(image_bytes)
+
+        results = []
+        for face in faces:
+            if face["score"] < min_score:
+                continue
+
+            if "landmarks" in face:
+                embedding = get_face_embedding(image_bytes, face["landmarks"], model_name)
+            else:
+                embedding = get_face_embedding_from_bbox(image_bytes, face["boundingBox"], model_name)
+
+            if embedding is not None:
+                results.append({
+                    "boundingBox": face["boundingBox"],
+                    "embedding": str(embedding.tolist()),
+                    "score": face["score"]
+                })
+
+        return results
+    finally:
+        _track_model_use("face")
 
 
 @app.get("/")
@@ -322,7 +343,8 @@ async def health():
         if not STUB_MODE:
             # Check CLIP model
             try:
-                clip = get_clip(settings.clip_model)
+                get_clip(settings.clip_model)
+                _track_model_use("clip")
                 health_status["checks"]["clip"] = "ok"
             except Exception as e:
                 logger.error(f"CLIP health check failed: {e}")
@@ -451,32 +473,38 @@ async def _process_predict(
         if task_type == "clip":
             if "visual" in task_config and image_bytes:
                 model_name = task_config["visual"].get("modelName", settings.clip_model)
-                
+
                 if STUB_MODE:
                     embedding = np.random.randn(512).astype(np.float32)
                     embedding = embedding / np.linalg.norm(embedding)
                 else:
                     clip = get_clip(model_name)
-                    embedding = await asyncio.to_thread(
-                        clip.encode_image,
-                        image_bytes
-                    )
-                
+                    try:
+                        embedding = await asyncio.to_thread(
+                            clip.encode_image,
+                            image_bytes
+                        )
+                    finally:
+                        _track_model_use("clip")
+
                 response["clip"] = str(embedding.tolist())
-                
+
             elif "textual" in task_config and text:
                 model_name = task_config["textual"].get("modelName", settings.clip_model)
-                
+
                 if STUB_MODE:
                     embedding = np.random.randn(512).astype(np.float32)
                     embedding = embedding / np.linalg.norm(embedding)
                 else:
                     clip = get_clip(model_name)
-                    embedding = await asyncio.to_thread(
-                        clip.encode_text,
-                        text
-                    )
-                
+                    try:
+                        embedding = await asyncio.to_thread(
+                            clip.encode_text,
+                            text
+                        )
+                    finally:
+                        _track_model_use("clip")
+
                 response["clip"] = str(embedding.tolist())
         
         elif task_type == "facial-recognition":

--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,8 @@ import io
 import os
 import logging
 import asyncio
+import time as _time
+import threading as _threading
 from contextlib import asynccontextmanager
 from pydantic import BaseModel, Field
 
@@ -25,6 +27,58 @@ logger = logging.getLogger(__name__)
 
 # Use real models unless STUB_MODE is set
 STUB_MODE = os.getenv("STUB_MODE", "false").lower() == "true"
+
+# --- Model idle unloading ---
+# Track last use time for each model type. When idle > timeout, unload
+# to free memory (~500MB CLIP, ~200MB ArcFace). Re-loads on next request.
+MODEL_IDLE_TIMEOUT = int(os.getenv("MODEL_IDLE_TIMEOUT", "120"))
+_model_last_used: dict[str, float] = {}
+_idle_monitor_started = False
+
+
+def _track_model_use(model_type: str) -> None:
+    """Record that a model was just used."""
+    _model_last_used[model_type] = _time.monotonic()
+
+
+def _start_idle_monitor() -> None:
+    """Start background thread that unloads idle models."""
+    global _idle_monitor_started
+    if _idle_monitor_started or STUB_MODE or MODEL_IDLE_TIMEOUT <= 0:
+        return
+    _idle_monitor_started = True
+
+    def _monitor():
+        while True:
+            _time.sleep(30)
+            now = _time.monotonic()
+            for model_type in list(_model_last_used.keys()):
+                idle_sec = now - _model_last_used.get(model_type, now)
+                if idle_sec < MODEL_IDLE_TIMEOUT:
+                    continue
+                try:
+                    if model_type == "clip":
+                        from .models import clip as clip_module
+                        with clip_module._model_lock:
+                            if clip_module._current_model is not None:
+                                clip_module._current_model.unload()
+                                clip_module._current_model = None
+                                clip_module._current_model_name = None
+                                logger.info("Unloaded CLIP model (idle %.0fs)", idle_sec)
+                        _model_last_used.pop("clip", None)
+                    elif model_type == "face":
+                        from .models import face_embed as face_module
+                        if face_module._recognition_model is not None:
+                            face_module.unload_recognition_model()
+                            logger.info("Unloaded face model (idle %.0fs)", idle_sec)
+                        _model_last_used.pop("face", None)
+                except Exception as e:
+                    logger.warning("Idle unload failed for %s: %s", model_type, e)
+
+    t = _threading.Thread(target=_monitor, daemon=True, name="model-idle-monitor")
+    t.start()
+    logger.info("Model idle monitor started (timeout=%ds)", MODEL_IDLE_TIMEOUT)
+
 
 if STUB_MODE:
     logger.warning("Running in STUB_MODE - returning fake data")
@@ -83,8 +137,9 @@ async def lifespan(app: FastAPI):
     logger.info(f"Max concurrent requests: {settings.max_concurrent_requests}")
     logger.info(f"Log level: {settings.log_level}")
     
+    _start_idle_monitor()
     yield
-    
+
     # Cleanup on shutdown - import modules to access current state
     logger.info("Shutting down immich-ml-metal service")
     if not STUB_MODE:
@@ -131,6 +186,7 @@ def get_clip(model_name: str = "ViT-B-32__openai"):
     if STUB_MODE:
         return None
     from .models.clip import get_clip_model
+    _track_model_use("clip")
     return get_clip_model(model_name)
 
 
@@ -156,6 +212,7 @@ def _run_face_recognition_sync(
     """Synchronous face recognition implementation."""
     from .models.face_detect import detect_faces
     from .models.face_embed import get_face_embedding, get_face_embedding_from_bbox
+    _track_model_use("face")
     
     faces, _, _ = detect_faces(image_bytes)
     

--- a/src/main.py
+++ b/src/main.py
@@ -28,10 +28,19 @@ logger = logging.getLogger(__name__)
 # Use real models unless STUB_MODE is set
 STUB_MODE = os.getenv("STUB_MODE", "false").lower() == "true"
 
-# --- Model idle unloading ---
-# Track last use time for each model type. When idle > timeout, unload
-# to free memory (~500MB CLIP, ~200MB ArcFace). Re-loads on next request.
+# --- Model memory management ---
+# Models stay loaded for fast inference. Under memory pressure, idle models
+# are unloaded to prevent swap spirals. Re-loaded automatically on next request.
+#
+# MODEL_UNLOAD_STRATEGY:
+#   "pressure" (default) — only unload when available RAM is low AND model is idle
+#   "timeout"            — unload after MODEL_IDLE_TIMEOUT seconds of inactivity
+#   "never"              — keep models loaded permanently
+MODEL_UNLOAD_STRATEGY = os.getenv("MODEL_UNLOAD_STRATEGY", "pressure")
 MODEL_IDLE_TIMEOUT = int(os.getenv("MODEL_IDLE_TIMEOUT", "120"))
+MODEL_MEMORY_FLOOR_MB = int(os.getenv("MODEL_MEMORY_FLOOR_MB", "500"))
+# Minimum idle time before a model is eligible for pressure-based unloading
+_PRESSURE_IDLE_MIN_SEC = 30
 _model_last_used: dict[str, float] = {}
 _idle_monitor_started = False
 
@@ -41,10 +50,70 @@ def _track_model_use(model_type: str) -> None:
     _model_last_used[model_type] = _time.monotonic()
 
 
+def _available_memory_mb() -> int:
+    """Check available memory (free + inactive pages) via vm_stat."""
+    try:
+        import subprocess
+        import re
+        vm = subprocess.check_output(["vm_stat"], timeout=5).decode()
+        ps_match = re.search(r"page size of (\d+) bytes", vm)
+        page_size = int(ps_match.group(1)) if ps_match else 16384
+        free_match = re.search(r"Pages free:\s+(\d+)", vm)
+        inactive_match = re.search(r"Pages inactive:\s+(\d+)", vm)
+        if not free_match or not inactive_match:
+            return 9999
+        free = int(free_match.group(1))
+        inactive = int(inactive_match.group(1))
+        return (free + inactive) * page_size // (1024 * 1024)
+    except Exception:
+        return 9999
+
+
+def _should_unload(model_type: str, now: float, avail_mb: int) -> bool:
+    """Decide whether a model should be unloaded based on strategy.
+
+    avail_mb is passed in so the caller can check memory once per cycle,
+    not once per model.
+    """
+    last_used = _model_last_used.get(model_type, now)
+    idle_sec = now - last_used
+
+    if MODEL_UNLOAD_STRATEGY == "never":
+        return False
+    elif MODEL_UNLOAD_STRATEGY == "timeout":
+        return idle_sec >= MODEL_IDLE_TIMEOUT
+    else:  # "pressure" — default
+        if idle_sec < _PRESSURE_IDLE_MIN_SEC:
+            return False  # actively in use, don't touch
+        return avail_mb < MODEL_MEMORY_FLOOR_MB
+
+
+def _unload_model(model_type: str, reason: str) -> None:
+    """Unload a specific model and log the reason."""
+    try:
+        if model_type == "clip":
+            from .models import clip as clip_module
+            with clip_module._model_lock:
+                if clip_module._current_model is not None:
+                    clip_module._current_model.unload()
+                    clip_module._current_model = None
+                    clip_module._current_model_name = None
+                    logger.info("Unloaded CLIP model (%s)", reason)
+            _model_last_used.pop("clip", None)
+        elif model_type == "face":
+            from .models import face_embed as face_module
+            if face_module._recognition_model is not None:
+                face_module.unload_recognition_model()
+                logger.info("Unloaded face model (%s)", reason)
+            _model_last_used.pop("face", None)
+    except Exception as e:
+        logger.warning("Model unload failed for %s: %s", model_type, e)
+
+
 def _start_idle_monitor() -> None:
-    """Start background thread that unloads idle models."""
+    """Start background thread that manages model memory."""
     global _idle_monitor_started
-    if _idle_monitor_started or STUB_MODE or MODEL_IDLE_TIMEOUT <= 0:
+    if _idle_monitor_started or STUB_MODE or MODEL_UNLOAD_STRATEGY == "never":
         return
     _idle_monitor_started = True
 
@@ -52,32 +121,20 @@ def _start_idle_monitor() -> None:
         while True:
             _time.sleep(30)
             now = _time.monotonic()
+            avail_mb = _available_memory_mb()
             for model_type in list(_model_last_used.keys()):
-                idle_sec = now - _model_last_used.get(model_type, now)
-                if idle_sec < MODEL_IDLE_TIMEOUT:
-                    continue
-                try:
-                    if model_type == "clip":
-                        from .models import clip as clip_module
-                        with clip_module._model_lock:
-                            if clip_module._current_model is not None:
-                                clip_module._current_model.unload()
-                                clip_module._current_model = None
-                                clip_module._current_model_name = None
-                                logger.info("Unloaded CLIP model (idle %.0fs)", idle_sec)
-                        _model_last_used.pop("clip", None)
-                    elif model_type == "face":
-                        from .models import face_embed as face_module
-                        if face_module._recognition_model is not None:
-                            face_module.unload_recognition_model()
-                            logger.info("Unloaded face model (idle %.0fs)", idle_sec)
-                        _model_last_used.pop("face", None)
-                except Exception as e:
-                    logger.warning("Idle unload failed for %s: %s", model_type, e)
+                if _should_unload(model_type, now, avail_mb):
+                    idle_sec = now - _model_last_used.get(model_type, now)
+                    if MODEL_UNLOAD_STRATEGY == "timeout":
+                        reason = "idle %.0fs" % idle_sec
+                    else:
+                        reason = "memory pressure, %dMB available, idle %.0fs" % (
+                            avail_mb, idle_sec)
+                    _unload_model(model_type, reason)
 
-    t = _threading.Thread(target=_monitor, daemon=True, name="model-idle-monitor")
+    t = _threading.Thread(target=_monitor, daemon=True, name="model-memory-monitor")
     t.start()
-    logger.info("Model idle monitor started (timeout=%ds)", MODEL_IDLE_TIMEOUT)
+    logger.info("Model memory monitor started (strategy=%s)", MODEL_UNLOAD_STRATEGY)
 
 
 if STUB_MODE:

--- a/src/models/face_detect.py
+++ b/src/models/face_detect.py
@@ -4,15 +4,14 @@ Face detection using Apple's Vision framework.
 Runs on the Neural Engine (ANE) for hardware acceleration.
 """
 
+import io
+import logging
+from typing import Optional
+
 import numpy as np
 from PIL import Image
-import io
-from typing import Optional
-import logging
-import objc
 from Foundation import NSData, NSAutoreleasePool
 import Vision
-import Quartz
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +86,9 @@ def _detect_faces_impl(
             
             landmarks = observation.landmarks()
             if landmarks:
-                five_points = extract_five_point_landmarks(landmarks, img_width, img_height)
+                five_points = extract_five_point_landmarks(
+                    landmarks, bbox, img_width, img_height
+                )
                 if five_points is not None:
                     face_data["landmarks"] = five_points
             
@@ -103,19 +104,56 @@ def _detect_faces_impl(
 
 def extract_five_point_landmarks(
     landmarks: "Vision.VNFaceLandmarks2D",
+    face_bbox,
     img_width: int,
     img_height: int
 ) -> Optional[list[list[float]]]:
     """
     Extract 5 landmark points for ArcFace alignment:
     - Left eye center
-    - Right eye center  
+    - Right eye center
     - Nose tip
     - Left mouth corner
     - Right mouth corner
-    
+
+    IMPORTANT: Vision framework's normalizedPoints are in the coordinate space
+    of the face's bounding box (0..1 within the bbox), NOT the full image.
+    We must map them through the face bounding box to get image pixel coords.
+    See: VNImagePointForFaceLandmarkPoint() in VNUtils.h
+
+    Args:
+        landmarks: VNFaceLandmarks2D from the face observation
+        face_bbox: The face observation's boundingBox() (normalized, bottom-left origin)
+        img_width: Full image width in pixels
+        img_height: Full image height in pixels
+
     Returns list of [x, y] points in pixel coordinates, or None if not available.
     """
+    # Extract the face bounding box in normalized coords (bottom-left origin)
+    bbox_x = face_bbox.origin.x
+    bbox_y = face_bbox.origin.y
+    bbox_w = face_bbox.size.width
+    bbox_h = face_bbox.size.height
+
+    def landmark_to_image_coords(norm_x: float, norm_y: float) -> list[float]:
+        """
+        Convert a landmark point from face-bbox-relative normalized coords
+        to full image pixel coords.
+
+        normalizedPoints are in face bbox space (0..1), with bottom-left origin.
+        Face bbox is in image normalized space (0..1), with bottom-left origin.
+        Final image pixels use top-left origin.
+        """
+        # Map from face-bbox-relative to image-normalized coords
+        img_norm_x = bbox_x + norm_x * bbox_w
+        img_norm_y = bbox_y + norm_y * bbox_h
+
+        # Convert to pixel coords (flip Y: Vision uses bottom-left origin)
+        px_x = img_norm_x * img_width
+        px_y = (1.0 - img_norm_y) * img_height
+
+        return [px_x, px_y]
+
     def get_region_points(region) -> list:
         """Convert PyObjC varlist to Python list of points."""
         if region is None:
@@ -125,58 +163,55 @@ def extract_five_point_landmarks(
             return []
         raw_points = region.normalizedPoints()
         return [raw_points[i] for i in range(point_count)]
-    
+
     def get_region_center(region) -> Optional[list[float]]:
-        """Get center point of a landmark region."""
+        """Get center point of a landmark region in image pixel coordinates."""
         points = get_region_points(region)
         if not points:
             return None
-        
+
         x_sum = sum(p.x for p in points)
         y_sum = sum(p.y for p in points)
         n = len(points)
-        
-        # Convert to pixels (flip Y)
-        x = (x_sum / n) * img_width
-        y = (1.0 - y_sum / n) * img_height
-        return [x, y]
-    
+
+        return landmark_to_image_coords(x_sum / n, y_sum / n)
+
     try:
         # Left eye center
         left_eye = get_region_center(landmarks.leftEye())
-        
+
         # Right eye center
         right_eye = get_region_center(landmarks.rightEye())
-        
+
         # Nose tip - use last point of nose region
         nose = None
         nose_points = get_region_points(landmarks.nose())
         if nose_points:
             p = nose_points[-1]
-            nose = [p.x * img_width, (1.0 - p.y) * img_height]
-        
+            nose = landmark_to_image_coords(p.x, p.y)
+
         # Mouth corners - find leftmost and rightmost points by x-coordinate
         # (Vision framework doesn't guarantee point ordering in contours)
         left_mouth = None
         right_mouth = None
         outer_lips_points = get_region_points(landmarks.outerLips())
         if outer_lips_points:
-            # Convert all points to pixel coordinates
+            # Convert all points to image pixel coordinates
             lips_px = [
-                (p.x * img_width, (1.0 - p.y) * img_height) 
+                landmark_to_image_coords(p.x, p.y)
                 for p in outer_lips_points
             ]
             # Find extremes by x-coordinate
-            left_mouth = list(min(lips_px, key=lambda p: p[0]))
-            right_mouth = list(max(lips_px, key=lambda p: p[0]))
-        
+            left_mouth = min(lips_px, key=lambda p: p[0])
+            right_mouth = max(lips_px, key=lambda p: p[0])
+
         # All 5 points must be present
         if all([left_eye, right_eye, nose, left_mouth, right_mouth]):
             return [left_eye, right_eye, nose, left_mouth, right_mouth]
-        
+
         logger.debug("Could not extract all 5 landmark points")
         return None
-        
+
     except Exception as e:
         logger.warning(f"Landmark extraction failed: {e}")
         return None


### PR DESCRIPTION
Vision framework's `normalizedPoints()` returns coordinates relative to the face's bounding box (0..1 within the bbox), not the full image. The existing code multiplied these directly by image width/height, which places every face's landmarks at roughly the same position regardless of where the face actually is in the image. This means `norm_crop` produces nearly identical alignment warps for all faces, and ArcFace generates the same embedding for everyone.

The fix maps landmark points through the face bounding box first:

```python
img_norm_x = bbox_x + norm_x * bbox_w
img_norm_y = bbox_y + norm_y * bbox_h
px_x = img_norm_x * img_width
px_y = (1.0 - img_norm_y) * img_height
```

Apple documents this in `VNUtils.h` which provides `VNImagePointForFaceLandmarkPoint()` for exactly this conversion.

Also cleaned up unused imports (Quartz, objc).

Tested on Mac Mini M4 running Immich v2.6.1. Face detection still works, embeddings now vary correctly between different faces.