### PR TITLE
Fix OCR bbox calculation

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -212,7 +212,7 @@ class FaceDetection(BaseModel):
 
 class OCRResult(BaseModel):
     text: list[str]
-    box: list[int]  # Flat list of coordinates
+    box: list[float]  # Flat list of coordinates
     boxScore: list[float]
     textScore: list[float]
 
@@ -616,22 +616,22 @@ async def _process_predict(
                 {
                     "text": ["placeholder", "text"],
                     "box": [
-                        0,
-                        0,
-                        100,
-                        0,
-                        100,
-                        50,
-                        0,
-                        50,
-                        0,
-                        50,
-                        100,
-                        50,
-                        100,
-                        100,
-                        0,
-                        100,
+                        0.1,
+                        0.3,
+                        0.5,
+                        0.3,
+                        0.5,
+                        0.4,
+                        0.1,
+                        0.4,
+                        0.2,
+                        0.4,
+                        0.6,
+                        0.4,
+                        0.6,
+                        0.5,
+                        0.2,
+                        0.5,
                     ],
                     "boxScore": [0.95, 0.92],
                     "textScore": [0.98, 0.96],

--- a/src/models/ocr.py
+++ b/src/models/ocr.py
@@ -116,18 +116,18 @@ def _recognize_text_impl(
             # Get bounding box (normalized coordinates, origin at bottom-left)
             bbox = observation.boundingBox()
             
-            # Convert to pixel coordinates (flip Y axis)
-            x = bbox.origin.x * img_width
-            y = (1.0 - bbox.origin.y - bbox.size.height) * img_height
-            w = bbox.size.width * img_width
-            h = bbox.size.height * img_height
+            # Calculate coordinates (flip Y axis)
+            x = bbox.origin.x
+            y = 1.0 - bbox.origin.y - bbox.size.height
+            w = bbox.size.width
+            h = bbox.size.height
             
             # Immich expects 8 coordinates per box (quadrilateral corners)
             # Order: top-left, top-right, bottom-right, bottom-left (clockwise)
-            x1, y1 = int(x), int(y)              # top-left
-            x2, y2 = int(x + w), int(y)          # top-right
-            x3, y3 = int(x + w), int(y + h)      # bottom-right
-            x4, y4 = int(x), int(y + h)          # bottom-left
+            x1, y1 = x, y              # top-left
+            x2, y2 = x + w, y          # top-right
+            x3, y3 = x + w, y + h      # bottom-right
+            x4, y4 = x, y + h          # bottom-left
             
             boxes.extend([x1, y1, x2, y2, x3, y3, x4, y4])
             


### PR DESCRIPTION
The database entries in asset_ocr table are supposed to be relative values in range [0..1]. The current code erroneously converted these to pixel values (similar to face detection, where such conversion is correct), however the client code expects relative values and as consequence it is unable to show OCR bounding boxes.

#9 